### PR TITLE
fix wrong return type in cache interface

### DIFF
--- a/src/i18nCacheInterface.php
+++ b/src/i18nCacheInterface.php
@@ -27,5 +27,5 @@ interface i18nCacheInterface
      * @param           string          $string         name of the property to call
      * @param           array           $args           arguments for translation
      */
-    public static function __callStatic(string $string, array|null $args) : void;
+    public static function __callStatic(string $string, array|null $args) : mixed;
 }


### PR DESCRIPTION
`__callStatic()` method in returns `mixed`
fix wrong type in cache interface